### PR TITLE
Update settings without delete 

### DIFF
--- a/i18n/browser/en.json
+++ b/i18n/browser/en.json
@@ -8,6 +8,11 @@
       },
       "tab-title": "Not connected"
     },
+    "notifications": {
+      "fight-turn": "Turn start for ",
+      "private-message": "Incoming message from ",
+      "tax-collector": "A tax collector is attacked!"
+    },
     "option": {
       "general": {
         "title": "General",
@@ -71,7 +76,8 @@
         "title": "Notifications",
         "description": "You can receive notifications from the game when the application is on the background. You will be notified:",
         "fight-turn": "When your turn starts (fight)",
-        "private-message": "By incoming private messages"
+        "private-message": "By incoming private messages",
+        "tax-collector": "When a tax collector is attacked"
       },
       "reset": "Reset",
       "save": "Apply"

--- a/i18n/browser/es.json
+++ b/i18n/browser/es.json
@@ -8,6 +8,11 @@
       },
       "tab-title": "Not connected"
     },
+    "notifications": {
+      "fight-turn": "Turn start for ",
+      "private-message": "Incoming message from ",
+      "tax-collector": "A tax collector is attacked!"
+    },
     "option": {
       "general": {
         "title": "General",
@@ -71,7 +76,8 @@
         "title": "Notifications",
         "description": "You can receive notifications from the game when the application is on the background. You will be notified:",
         "fight-turn": "When your turn starts (fight)",
-        "private-message": "By incoming private messages"
+        "private-message": "By incoming private messages",
+        "tax-collector": "When a tax collector is attacked"
       },
       "reset": "Reset",
       "save": "Apply"

--- a/i18n/browser/fr.json
+++ b/i18n/browser/fr.json
@@ -8,6 +8,11 @@
       },
       "tab-title": "Non connecté"
     },
+    "notifications": {
+      "fight-turn": "Début du tour de ",
+      "private-message": "Message de : ",
+      "tax-collector": "Un percepteur est attaqué !"
+    },
     "option": {
       "general": {
         "title": "Général",
@@ -71,7 +76,8 @@
         "title": "Notifications",
         "description": "Vous pouvez recevoir des notifications de votre jeu dofus lorsque vous êtes sur une autre application avec dofus en arrière plan. Vous pouvez être notifié :",
         "fight-turn": "En début du tour (combat)",
-        "private-message": "À l'arrivé d'un message privé"
+        "private-message": "À l'arrivé d'un message privé",
+        "tax-collector": "Quand un percepteur est attaqué"
       },
       "reset": "Réinitialiser",
       "save": "Valider"

--- a/src/browser/app/option/notification/notification.component.html
+++ b/src/browser/app/option/notification/notification.component.html
@@ -21,5 +21,15 @@
                 </div>
             </div>
         </div>
+        <div class="form-group">
+            <div class="col-offset-3 col-10">
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" class="shortcut"
+                               [(ngModel)]="settingsService.option.notification.tax_collector"> {{ 'app.option.notifications.tax-collector' | translate }}
+                    </label>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/browser/shared/settings/settings.service.ts
+++ b/src/browser/shared/settings/settings.service.ts
@@ -493,6 +493,7 @@ export module Option {
     export class Notification {
         private _private_message: boolean;
         private _fight_turn: boolean;
+        private _tax_collector: boolean;
 
         get private_message() {
             return this._private_message;
@@ -512,9 +513,19 @@ export module Option {
             this._fight_turn = fight_turn;
         }
 
+        get tax_collector() {
+            return this._tax_collector;
+        }
+
+        set tax_collector(tax_collector: any) {
+            settings.setSync('option.notification.tax_collector', tax_collector);
+            this._tax_collector = tax_collector;
+        }
+
         constructor() {
             this.fight_turn = settings.getSync('option.notification.fight_turn');
             this.private_message = settings.getSync('option.notification.private_message');
+            this.tax_collector = settings.getSync('option.notification.tax_collector');
         }
     }
 }

--- a/src/electron/application.ts
+++ b/src/electron/application.ts
@@ -42,9 +42,11 @@ export class Application {
         settings.defaults(DefaultSettings);
 
         // if wrong settings -> reset
+        settings.applyDefaultsSync();
         if (!checkSettings()) {
             settings.resetToDefaultsSync();
         }
+
 
 
         if (!settings.getSync('language')) {

--- a/src/electron/default.settings.ts
+++ b/src/electron/default.settings.ts
@@ -130,7 +130,8 @@ export const DefaultSettings: ISettings = {
         },
         notification:{
             private_message: true,
-            fight_turn: true
+            fight_turn: true,
+            tax_collector: true
         }
     }
 };

--- a/src/electron/test/check-settings.ts
+++ b/src/electron/test/check-settings.ts
@@ -1,10 +1,11 @@
 import {ISettings} from "../../shared/settings";
+import {DefaultSettings} from '../default.settings';
 const settings = require('electron-settings');
 
 export function checkSettings(){
     let sett:ISettings = settings.getSync();
 
-    if(Number.isInteger(sett.alertCounter)
+    /*if(Number.isInteger(sett.alertCounter)
         && sett.appVersion
         && sett.buildVersion
         && typeof(sett.option.general.hidden_shop) === "boolean"
@@ -50,8 +51,32 @@ export function checkSettings(){
         ){
         console.log('check settings OK');
         return true;
-    }
+    }*/
 
-    console.log('check settings FAILED');
-    return false;
+    function checkRecursive(settings: any, defaultSettings: any) {
+        for (var id in defaultSettings) {
+            if (Array.isArray(defaultSettings[id])) {
+                if (!Array.isArray(settings[id])) return false;
+            }
+            else {
+                if (typeof defaultSettings[id] !== typeof settings[id] && defaultSettings[id] !== null) return false;
+            }
+            if (typeof defaultSettings[id] === 'object') {
+                if (!checkRecursive(settings[id], defaultSettings[id])) return false;
+            }
+        }
+        return true;
+    }
+    var ok = checkRecursive(sett, DefaultSettings);
+
+
+    sett.alertCounter = Math.floor(sett.alertCounter);
+    sett.option.general.resolution.x = Math.floor(sett.option.general.resolution.x);
+    sett.option.general.resolution.y = Math.floor(sett.option.general.resolution.y);
+
+    if (ok) console.log('check settings OK');
+    else console.log('check settings FAILED');
+
+
+    return ok;
 }

--- a/src/electron/test/check-settings.ts
+++ b/src/electron/test/check-settings.ts
@@ -46,6 +46,7 @@ export function checkSettings(){
         && typeof(sett.option.shortcuts.interface.goultine) === "string"
         && typeof(sett.option.notification.private_message) === "boolean"
         && typeof(sett.option.notification.fight_turn) === "boolean"
+        && typeof(sett.option.notification.tax_collector) === "boolean"
         ){
         console.log('check settings OK');
         return true;

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -60,6 +60,7 @@ export interface ISettings {
         notification: {
             private_message: boolean;
             fight_turn: boolean;
+            tax_collector: boolean;
         }
     }
 }


### PR DESCRIPTION
La ligne 45 dans application.ts (settings.applyDefaultsSync();) permet d'appliquer les paramètres par défaut uniquement si le paramètre correspondant est manquant (on évite de tout écraser).

Pour check-settings.js, j'ai laissé ce que j'avais fais à la base si ça peut servir. Au lieu d'ajouter une ligne à chaque nouvelle option, il compare automatiquement les types des valeurs actuelles et de celles par défaut.
Si tu pense que ça risque de foutre la merde tu peux le virer.