### PR TITLE
Life bar fixes & improvements

### DIFF
--- a/src/browser/app/main/game/health-bar/bar.ts
+++ b/src/browser/app/main/game/health-bar/bar.ts
@@ -2,7 +2,6 @@ export class Bar {
 
     private fighter: any;
     private wGame: any;
-    private updateInterval: NodeJS.Timer;
 
     private lifeBarContainer : HTMLDivElement;
     private lifeBar : HTMLDivElement;
@@ -14,21 +13,16 @@ export class Bar {
 
         this.createBar();
 
-        this.updateInterval = setInterval(()=>{
-            this.updateBar();
-        }, 400);
-
     }
 
-    private updateBar(){
+    public getId(){
+        return this.fighter.id;
+    }
+
+    public update(){
         let fighter = this.wGame.gui.fightManager.getFighter(this.fighter.id);
 
-        if (!this.wGame.isoEngine.mapRenderer.isFightMode) {
-            clearInterval(this.updateInterval);
-            this.updateInterval = null;
-            this.wGame.document.getElementById('lifeBars').innerHTML = '';
-        }
-        else {
+        if (this.wGame.isoEngine.mapRenderer.isFightMode) {
 
             if (fighter.data.alive) {
                 if (!this.lifeBar || !this.lifeBarContainer || !this.lifePointsEl) {
@@ -68,10 +62,10 @@ export class Bar {
         /* lifeBar */
         this.lifeBar = document.createElement('div');
         this.lifeBar.id = 'fighterLifeBar' + this.fighter.id;
-        this.lifeBar.style.cssText = 'background-color: red; transition-duration: 300ms; height: 100%; width: ' + Math.round(life * 100) + '%;';
+        this.lifeBar.style.cssText = 'transition-duration: 300ms; height: 100%; width: ' + Math.round(life * 100) + '%;';
 
-        if (!this.wGame.gui.fightManager.isFighterOnUsersTeam(this.fighter.id))
-            this.lifeBar.style.backgroundColor = '#3ad';
+        if (this.fighter.data.teamId == 0) this.lifeBar.style.backgroundColor = 'red';
+        else this.lifeBar.style.backgroundColor = '#3ad';
         this.lifeBarContainer.appendChild(this.lifeBar);
         this.lifeBarContainer.style.left = (pos.x - 40) + 'px';
         this.lifeBarContainer.style.top = (pos.y + 10) + 'px';
@@ -89,7 +83,6 @@ export class Bar {
     }
 
     public destroy(){
-        clearInterval(this.updateInterval);
         this.lifePointsEl.parentElement.removeChild(this.lifePointsEl);
         this.lifeBar.parentElement.removeChild(this.lifeBar);
         this.lifeBarContainer.parentElement.removeChild(this.lifeBarContainer);

--- a/src/browser/app/main/game/health-bar/healthbar.ts
+++ b/src/browser/app/main/game/health-bar/healthbar.ts
@@ -7,11 +7,20 @@ export class HealthBar {
     private wGame: any | Window;
     private shortcuts: ShortCuts;
     private barContainer: BarContainer;
+    private fightJustStarted: boolean = false;
+    private events: any[];
 
     constructor(wGame: any, skipLogin: boolean = false) {
         this.wGame = wGame;
+        this.events = [];
         this.shortcuts = new ShortCuts(this.wGame);
         this.barContainer = new BarContainer(this.wGame);
+
+        this.removeOnDeath();
+        this.setFightStart();
+        this.displayOnStart();
+        this.stopOnFightEnd();
+
 
         this.shortcuts.bind('p', () => {
             console.log('start health bar');
@@ -20,9 +29,60 @@ export class HealthBar {
     }
 
 
+    private removeOnDeath(): void {
+        let onDeath = (e: any) => {
+            this.barContainer.destroyBar(e.targetId);
+        };
+
+        this.wGame.gui.on('GameActionFightDeathMessage', onDeath);
+        this.events.push(() => {
+            this.wGame.gui.removeListener('GameActionFightDeathMessage', onDeath);
+        });
+    }
+
+    private setFightStart(): void {
+        let onFightStart = (e: any) => {
+            this.fightJustStarted = true;
+        };
+
+        this.wGame.dofus.connectionManager.on('GameFightStartingMessage', onFightStart);
+        this.events.push(() => {
+            this.wGame.dofus.connectionManager.removeListener('GameFightStartingMessage', onFightStart);
+        });
+    }
+
+    private displayOnStart(): void {
+        let onNewRound = (e: any) => {
+            if (this.fightJustStarted) {
+                this.fightJustStarted = false;
+                this.barContainer.fightStarted();
+            }
+        };
+
+        this.wGame.dofus.connectionManager.on('GameFightNewRoundMessage', onNewRound);
+        this.events.push(() => {
+            this.wGame.dofus.connectionManager.removeListener('GameFightNewRoundMessage', onNewRound);
+        });
+    }
+
+    private stopOnFightEnd(): void {
+        let onFightEnd = (e: any) => {
+            this.barContainer.fightEnded();
+        };
+
+        this.wGame.dofus.connectionManager.on('GameFightEndMessage', onFightEnd);
+        this.events.push(() => {
+            this.wGame.dofus.connectionManager.removeListener('GameFightEndMessage', onFightEnd);
+        });
+    }
+
+
 
     public reset() {
-
+        this.events.forEach((event) => {
+            event();
+        });
+        this.events = [];
     }
 
 }


### PR DESCRIPTION
J'ai passé le update dans le container plutôt que dans chaque Bar individuellement.
En plus de "display" (renommé en "displayed"), j'ai ajouté "enabled", qui est un état persistant entre chaque combat, pour savoir si les barres sont activées ou non.
Les events de mort / début de combat / fin de combat sont dans healthbar
J'ai volontairement retiré l'affichage des barres en phase de placement parce que le cellId est pas update correctement lorsque le joueur change de case.